### PR TITLE
Update readyState check

### DIFF
--- a/dist/fast-image-zoom.js
+++ b/dist/fast-image-zoom.js
@@ -262,7 +262,7 @@ var imageZoom = (function () {
 			cb();
 		};
 
-		if (document.readyState === 'interactive' || document.readyState === 'ready') {
+		if (document.readyState === 'interactive' || document.readyState === 'complete') {
 			start();
 		} else {
 			document.addEventListener('DOMContentLoaded', start);

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ export default (config = defaultConfig) => {
 		cb()
 	}
 
-	if (document.readyState === 'interactive' || document.readyState === 'ready') {
+	if (document.readyState === 'interactive' || document.readyState === 'complete') {
 		start()
 	} else {
 		document.addEventListener('DOMContentLoaded', start)


### PR DESCRIPTION
I wasn't able to reliably use `fast-image-zoom` in my project until I tweaked the `readyState` to check for `'complete'` instead of `'ready'`, which doesn't appear to be a valid value [according to MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState). Here's the TypeScript DOM definition too:

```ts
type DocumentReadyState = "complete" | "interactive" | "loading";
```